### PR TITLE
Fix nmodl uninitialized variables

### DIFF
--- a/mechanisms/dbbs/Cav2_1.mod
+++ b/mechanisms/dbbs/Cav2_1.mod
@@ -20,7 +20,7 @@ Contact: Sungho Hong (shhong@oist.jp)
 ENDCOMMENT
 
 NEURON {
-SUFFIX Cav2_1
+    SUFFIX Cav2_1
     USEION ca READ cai, cao WRITE ica
     RANGE pcabar, ica, gk, vhalfm, cvm, vshift, taum, minf
 }
@@ -59,12 +59,12 @@ PARAMETER {
 
 ASSIGNED {
     qt
-    T (kelvin)
     minf
     taum (ms)
+    gk (coulombs/cm3)
+    T (kelvin)
     E (volt)
     zeta
-    gk (coulombs/cm3)
 }
 
 STATE { m }
@@ -87,24 +87,23 @@ DERIVATIVE states {
     m' = (minf-m)/taum
 }
 
-PROCEDURE rates( v (mV), cai, cao ) {
-    LOCAL shifted
-    shifted = v - vshift
+FUNCTION ghk( v (mV), ci (mM), co (mM), z)  (coulombs/cm3) {
+    E = (1e-3) * v
+    zeta = (z*F*E)/(R*T)
 
-    minf = 1 / ( 1 + exp(-(v-vhalfm-vshift)/cvm) )
-    taum = taumfkt(shifted)/qt
-    E = (1e-3) * shifted
-    zeta = (2*F*E)/(R*T)
-    gk = ghk(shifted, cai, cao, zeta, 2)
-}
-
-FUNCTION ghk( v (mV), ci (mM), co (mM), ze, z )  (coulombs/cm3) {
     if ( fabs(1-exp(-zeta)) < 1e-6 ) {
         ghk = (1e-6) * (z*F) * (ci - co*exp(-zeta)) * (1 + zeta/2)
     } else {
         ghk = (1e-6) * (z*zeta*F) * (ci - co*exp(-zeta)) / (1-exp(-zeta))
     }
 }
+
+PROCEDURE rates( v (mV), cai, cao ) {
+    minf = 1 / ( 1 + exp(-(v-vhalfm-vshift)/cvm) )
+    taum = taumfkt(v-vshift)/qt
+    gk = ghk(v-vshift, cai, cao, 2)
+}
+
 
 
 FUNCTION kelvinfkt( t (degC) )  (kelvin) {
@@ -113,12 +112,12 @@ FUNCTION kelvinfkt( t (degC) )  (kelvin) {
     UNITSON
 }
 
-FUNCTION taumfkt( vm (mV) ) (ms) {
+FUNCTION taumfkt( v (mV) ) (ms) {
     UNITSOFF
-    if (vm>=-40) {
-        taumfkt = 0.2702 + 1.1622 * exp(-(vm+26.798)*(vm+26.798)/164.19)
+    if (v>=-40) {
+        taumfkt = 0.2702 + 1.1622 * exp(-(v+26.798)*(v+26.798)/164.19)
     } else {
-        taumfkt = 0.6923 * exp(vm/1089.372)
+        taumfkt = 0.6923 * exp(v/1089.372)
     }
     UNITSON
 }

--- a/mechanisms/dbbs/Cav3_2.mod
+++ b/mechanisms/dbbs/Cav3_2.mod
@@ -17,83 +17,80 @@ TITLE Low threshold calcium current
 :   Suffix from CaT3_2 to Cav3_2
 
 NEURON {
-	SUFFIX Cav3_2
-	USEION ca READ cai, cao WRITE ica
-	RANGE gcabar, m_inf, tau_m, h_inf, tau_h, shift, i,ica
+    SUFFIX Cav3_2
+    USEION ca READ cai, cao WRITE ica
+    RANGE gcabar, m_inf, tau_m, h_inf, tau_h, shift, i,ica
 }
 
 UNITS {
-	(molar) = (1/liter)
-	(mV) =	(millivolt)
-	(mA) =	(milliamp)
-	(mM) =	(millimolar)
+    (molar) = (1/liter)
+    (mV) =  (millivolt)
+    (mA) =  (milliamp)
+    (mM) =  (millimolar)
 }
 
 CONSTANT {
-	FARADAY = 96485.3 (coul)
-	R = 8.31345 (joule/degC)
+    FARADAY = 96485.3 (coul)
+    R = 8.31345 (joule/degC)
 }
 
 PARAMETER {
-	v		(mV)
-	celsius	= 36	(degC)
-	gcabar	= .0008	(mho/cm2)
-	shift	= 0 	(mV)
+    v       (mV)
+    celsius = 36    (degC)
+    gcabar  = .0008 (mho/cm2)
+    shift   = 0     (mV)
 }
 
 STATE {
-	m h
+    m h
 }
 
 ASSIGNED {
-	carev	(mV)
-	m_inf
-	tau_m	(ms)
-	h_inf
-	tau_h	(ms)
-	phi_m
-	phi_h
-	i	(mA/cm2)
+    carev   (mV)
+    m_inf
+    tau_m   (ms)
+    h_inf
+    tau_h   (ms)
+    phi_m
+    phi_h
+    i   (mA/cm2)
 }
 
 BREAKPOINT {
-	SOLVE castate METHOD cnexp
-	carev = (1e3) * (R*(celsius+273.15))/(2*FARADAY) * log (cao/cai)
-	ica = gcabar * m*m*h * (v-carev)
-	i = ica		: diagnostic i added to display the current
+    SOLVE castate METHOD cnexp
+    carev = (1e3) * (R*(celsius+273.15))/(2*FARADAY) * log (cao/cai)
+    ica = gcabar * m*m*h * (v-carev)
+    i = ica     : diagnostic i added to display the current
 }
 
 DERIVATIVE castate {
-	evaluate_fct(v)
+    evaluate_fct(v)
 
-	m' = (m_inf - m) / tau_m
-	h' = (h_inf - h) / tau_h
+    m' = (m_inf - m) / tau_m
+    h' = (h_inf - h) / tau_h
 }
 
 UNITSOFF
 INITIAL {
-:
 :   Activation functions and kinetics were obtained from
 :   Vitko et al., 2005 at 23-25 deg.
 :   Transformation to 36 deg assuming Q10 of 5 and 3 for m and h
 :   (as in Coulter et al., J Physiol 414: 587, 1989)
 :
-	phi_m = 5 ^ (12/10)
-	phi_h = 3 ^ (12/10)
+    phi_m = 5 ^ (12/10)
+    phi_h = 3 ^ (12/10)
 
-	evaluate_fct(v)
+    evaluate_fct(v)
 
-	m = m_inf
-	h = h_inf
+    m = m_inf
+    h = h_inf
 }
 
 PROCEDURE evaluate_fct(v(mV)) {
-:
+    m_inf = 1.0 / ( 1 + exp(-(v+shift+54.8)/7.4) )
+    h_inf = 1.0 / ( 1 + exp((v+shift+85.5)/7.18) )
 
-	m_inf = 1.0 / ( 1 + exp(-(v+shift+54.8)/7.4) )
-	h_inf = 1.0 / ( 1 + exp((v+shift+85.5)/7.18) )
-
-	tau_m = ( 1.9 + 1.0 / ( exp((v+shift+37.0)/11.9) + exp(-(v+shift+131.6)/21) ) ) / phi_m
-	tau_h = 13.7 + (1942 + exp((v+shift+164)/9.2)) / (1 + exp((v+shift+89.3)/3.7) ) / phi_h
+    tau_m = ( 1.9 + 1.0 / ( exp((v+shift+37.0)/11.9) + exp(-(v+shift+131.6)/21) ) ) / phi_m
+    tau_h = 13.7 + (1942 + exp((v+shift+164)/9.2)) / (1 + exp((v+shift+89.3)/3.7) ) / phi_h
 }
 UNITSON

--- a/mechanisms/dbbs/Cav3_2.mod
+++ b/mechanisms/dbbs/Cav3_2.mod
@@ -30,8 +30,8 @@ UNITS {
 }
 
 CONSTANT {
-	FARADAY = 96520 (coul)
-	R = 8.3134 (joule/degC)
+	FARADAY = 96485.3 (coul)
+	R = 8.31345 (joule/degC)
 }
 
 PARAMETER {

--- a/mechanisms/dbbs/Cav3_3.mod
+++ b/mechanisms/dbbs/Cav3_3.mod
@@ -13,25 +13,25 @@ COMMENT
 ENDCOMMENT
 
 
- NEURON	{
-  SUFFIX Cav3_3
-  USEION ca READ cai, cao WRITE ica
-  RANGE gCav3_3bar, pcabar, ica, tau_l, tau_n, n_inf, l_inf
+NEURON {
+    SUFFIX Cav3_3
+    USEION ca READ cai, cao WRITE ica
+    RANGE gCav3_3bar, pcabar, ica, tau_l, tau_n, n_inf, l_inf
 }
 
-UNITS	{
-	(S) = (siemens)
-	(mV) = (millivolt)
-	(mA) = (milliamp)
+UNITS   {
+    (S) = (siemens)
+    (mV) = (millivolt)
+    (mA) = (milliamp)
 }
 
 CONSTANT {
-  F = 96520 : Farady constant (coulomb/mol)
-  R = 8.3134 : gas constant (J/K.mol)
-  PI = 3.14
+    F = 96520 : Farady constant (coulomb/mol)
+    R = 8.3134 : gas constant (J/K.mol)
+    PI = 3.14
 }
 
-PARAMETER	{
+PARAMETER   {
     celsius = 32
     gCav3_3bar = 0.00001 (S/cm2)
     vhalfn = -41.5  :mv
@@ -43,55 +43,55 @@ PARAMETER	{
     z= 2
 }
 
-ASSIGNED	{
-	v	(mV)
-	gCav3_3	(S/cm2)
-	n_inf
-	tau_n
-	l_inf
-	tau_l
-	qt
-	T  : absolute temperature (K)
-	ghk
-	w
+ASSIGNED    {
+    v   (mV)
+    gCav3_3 (S/cm2)
+    n_inf
+    tau_n
+    l_inf
+    tau_l
+    qt
+    T  : absolute temperature (K)
+    ghk
+    w
 }
 
-STATE	{
-	n
-	l
+STATE {
+    n
+    l
 }
 
-BREAKPOINT	{
+BREAKPOINT  {
     SOLVE states METHOD cnexp
     ica = gCav3_3bar*pcabar*n*n*l*ghk
 }
 
-DERIVATIVE states	{
-	rates(v, cai, cao)
-	n' = (n_inf-n)/tau_n
-	l' = (l_inf-l)/tau_l
-    }
-
-INITIAL {
-	T = celsius+273.14
-	qt = q10 ^ ((celsius-28) / 10)
-	rates(v, cai, cao)
-	n = n_inf
-	l = l_inf
+DERIVATIVE states {
+    rates(v, cai, cao)
+    n' = (n_inf-n)/tau_n
+    l' = (l_inf-l)/tau_l
 }
 
-PROCEDURE rates(v, cai, cao){
-	n_inf = 1/(1+exp(-(v-vhalfn)/kn))
-	l_inf = 1/(1+exp(-(v-vhalfl)/kl))
+INITIAL {
+    T = celsius+273.14
+    qt = q10 ^ ((celsius-28) / 10)
+    rates(v, cai, cao)
+    n = n_inf
+    l = l_inf
+}
 
-        if (v > -60) {
-            tau_n = (7.2+0.02*exp(-v/14.7))/qt
-	    tau_l = (79.5+2.0*exp(-v/9.3))/qt
-        }else{
-            tau_n = (0.875*exp((v+120)/41))/qt
-	    tau_l = 260/qt
-        }
+PROCEDURE rates(v, cai, cao) {
+    n_inf = 1/(1+exp(-(v-vhalfn)/kn))
+    l_inf = 1/(1+exp(-(v-vhalfl)/kl))
 
-      w = v*0.001*z*F/(R*T)
-      ghk = -0.001*z*F*(cao-cai*exp(w))*w/(exp(w)-1)
+    if (v > -60) {
+        tau_n = (7.2+0.02*exp(-v/14.7))/qt
+        tau_l = (79.5+2.0*exp(-v/9.3))/qt
+    } else {
+        tau_n = (0.875*exp((v+120)/41))/qt
+        tau_l = 260/qt
+    }
+
+    w = v*0.001*z*F/(R*T)
+    ghk = -0.001*z*F*(cao-cai*exp(w))*w/(exp(w)-1)
 }

--- a/mechanisms/dbbs/Cav3_3.mod
+++ b/mechanisms/dbbs/Cav3_3.mod
@@ -74,7 +74,7 @@ DERIVATIVE states	{
 
 INITIAL {
 	T = celsius+273.14
-	qt = q10 ^ (celsius-28) / 10
+	qt = q10 ^ ((celsius-28) / 10)
 	rates(v, cai, cao)
 	n = n_inf
 	l = l_inf

--- a/mechanisms/dbbs/HCN1.mod
+++ b/mechanisms/dbbs/HCN1.mod
@@ -7,26 +7,26 @@ We call it HCN1 as PC express only HCN1 Santoro et al. 2000
 ENDCOMMENT
 
 NEURON {
-	SUFFIX HCN1
-	USEION h READ eh WRITE ih VALENCE 1
-	RANGE gbar, hinf,tauh,ratetau,ih
-	RANGE hinf,tauh,eh
+    SUFFIX HCN1
+    USEION h READ eh WRITE ih VALENCE 1
+    RANGE gbar, hinf,tauh,ratetau,ih
+    RANGE hinf,tauh,eh
 }
 
 UNITS {
-	(mA) = (milliamp)
-	(mV) = (millivolt)
+    (mA) = (milliamp)
+    (mV) = (millivolt)
 }
 
 
 CONSTANT {
-	q10=3
+    q10=3
 }
 
 PARAMETER {
-    v 		(mV)
-	celsius (deg)
-    gbar=.0001 	(mho/cm2)
+    v       (mV)
+    celsius (deg)
+    gbar=.0001  (mho/cm2)
     ratetau = 1 (ms)
     rec_temp = 23 (deg) : we set it here at room temperature as in Angelo et al. they forogot tp mention the recording temperature
     ljp = 9.3 (mV) : liquid_junction_potential
@@ -37,7 +37,7 @@ PARAMETER {
     v_tau_half2_noljp = -68 (mV)
     v_tau_k1 = -22 (mv)
     v_tau_k2 = 7.14 (mv)
- }
+}
 
 STATE {
     h

--- a/mechanisms/dbbs/HCN1.mod
+++ b/mechanisms/dbbs/HCN1.mod
@@ -25,7 +25,7 @@ CONSTANT {
 
 PARAMETER {
     v 		(mV)
-		celsius (deg)
+	celsius (deg)
     gbar=.0001 	(mho/cm2)
     ratetau = 1 (ms)
     rec_temp = 23 (deg) : we set it here at room temperature as in Angelo et al. they forogot tp mention the recording temperature
@@ -53,14 +53,13 @@ ASSIGNED {
 }
 
 INITIAL {
-    rate(v)
-    h=hinf
     : ADD Q10 correction!!!!! FATTO!!!
     qt = q10^((celsius-37)/10)
     v_inf_half = (v_inf_half_noljp - ljp)
     v_tau_half1 = (v_tau_half1_noljp - ljp)
     v_tau_half2 = (v_tau_half2_noljp - ljp)
-
+    rate(v)
+    h=hinf
 }
 
 BREAKPOINT {

--- a/mechanisms/dbbs/Kca1_1.mod
+++ b/mechanisms/dbbs/Kca1_1.mod
@@ -18,11 +18,10 @@ Contact: Sungho Hong (shhong@oist.jp)
 ENDCOMMENT
 
 NEURON {
-  SUFFIX Kca1_1
-  USEION k READ ek WRITE ik
-  USEION ca READ cai
-  RANGE g, gbar, ik
-
+    SUFFIX Kca1_1
+    USEION k READ ek WRITE ik
+    USEION ca READ cai
+    RANGE g, gbar, ik
 }
 
 UNITS {
@@ -33,9 +32,9 @@ UNITS {
 }
 
 CONSTANT {
-  FARADAY = 96.4853
-  R = 8.31345 : gas constant (J/K.mol)
-  q10 = 3
+    FARADAY = 96.4853
+    R = 8.31345 : gas constant (J/K.mol)
+    q10 = 3
 }
 
 PARAMETER {
@@ -51,9 +50,9 @@ PARAMETER {
 
     L0 = 1806
     Kc = 11.0e-3 (mM)
-    Ko = 1.1e-3 (mM)
+    Ko = 1.1e-3  (mM)
 
-    pf0 = 2.39e-3  (/ms)
+    pf0 = 2.39e-3 (/ms)
     pf1 = 7.0e-3  (/ms)
     pf2 = 40e-3   (/ms)
     pf3 = 295e-3  (/ms)
@@ -63,7 +62,7 @@ PARAMETER {
     pb1 = 1152e-3 (/ms)
     pb2 = 659e-3  (/ms)
     pb3 = 486e-3  (/ms)
-    pb4 = 92e-3  (/ms)
+    pb4 = 92e-3   (/ms)
 }
 
 ASSIGNED {

--- a/mechanisms/dbbs/Kca1_1.mod
+++ b/mechanisms/dbbs/Kca1_1.mod
@@ -33,8 +33,8 @@ UNITS {
 }
 
 CONSTANT {
-  FARADAY = 96.520
-  R = 8.3134 : gas constant (J/K.mol)
+  FARADAY = 96.4853
+  R = 8.31345 : gas constant (J/K.mol)
   q10 = 3
 }
 

--- a/mechanisms/dbbs/Kv1_1.mod
+++ b/mechanisms/dbbs/Kv1_1.mod
@@ -31,107 +31,105 @@ Contact: akemann@brain.riken.jp
 
 ENDCOMMENT
 
-UNITSOFF
 NEURON {
-  SUFFIX Kv1_1
-	USEION k READ ek WRITE ik
-	NONSPECIFIC_CURRENT i
-	RANGE g, gbar, ik, i , igate, nc
-	RANGE ninf, taun
-	RANGE gateCurrent, gunit
+    SUFFIX Kv1_1
+    USEION k READ ek WRITE ik
+    NONSPECIFIC_CURRENT i
+    RANGE g, gbar, ik, i , igate, nc
+    RANGE ninf, taun
+    RANGE gateCurrent, gunit
 }
 
 UNITS {
-	(mV) = (millivolt)
-	(mA) = (milliamp)
-	(nA) = (nanoamp)
-	(pA) = (picoamp)
-	(S)  = (siemens)
-	(nS) = (nanosiemens)
-	(pS) = (picosiemens)
-	(um) = (micron)
-	(molar) = (1/liter)
-	(mM) = (millimolar)
+    (mV) = (millivolt)
+    (mA) = (milliamp)
+    (nA) = (nanoamp)
+    (pA) = (picoamp)
+    (S)  = (siemens)
+    (nS) = (nanosiemens)
+    (pS) = (picosiemens)
+    (um) = (micron)
+    (molar) = (1/liter)
+    (mM) = (millimolar)
 }
 
 CONSTANT {
-	e0 = 1.60217646e-19 (coulombs)
-	q10 = 2.7
+    e0 = 1.60217646e-19 (coulombs)
+    q10 = 2.7
 
-	ca = 0.12889 (1/ms)
-	cva = 45 (mV)
-	cka = -33.90877 (mV)
+    ca = 0.12889 (1/ms)
+    cva = 45 (mV)
+    cka = -33.90877 (mV)
 
-	cb = 0.12889 (1/ms)
+    cb = 0.12889 (1/ms)
       cvb = 45 (mV)
-	ckb = 12.42101 (mV)
+    ckb = 12.42101 (mV)
 
-	zn = 2.7978 (1)		: valence of n-gate
+    zn = 2.7978 (1)     : valence of n-gate
 }
 
 PARAMETER {
-	gateCurrent = 0 (1)	: gating currents ON = 1 OFF = 0
+    gateCurrent = 0 (1) : gating currents ON = 1 OFF = 0
 
-	gbar = 0.004 (S/cm2)   <0,1e9>
-	gunit = 16 (pS)		: unitary conductance
- 	celsius (degC)
-	v (mV)
+    gbar = 0.004 (S/cm2)   <0,1e9>
+    gunit = 16 (pS)     : unitary conductance
+    celsius (degC)
+    v (mV)
 }
 
 
 ASSIGNED {
-	igate (mA/cm2)
-	g  (S/cm2)
-	nc (1/cm2)			: membrane density of channel
+    igate (mA/cm2)
+    g  (S/cm2)
+    nc (1/cm2)          : membrane density of channel
 
-	ninf (1)
-	taun (ms)
-	alphan (1/ms)
-	betan (1/ms)
-	qt (1)
+    ninf (1)
+    taun (ms)
+    alphan (1/ms)
+    betan (1/ms)
+    qt (1)
 }
 
 STATE { n }
 
 INITIAL {
-	nc = (1e12) * gbar / gunit
-	qt = q10^((celsius-22)/10)
-	rates(v)
-	n = ninf
+    nc = (1e12) * gbar / gunit
+    qt = q10^((celsius-22)/10)
+    rates(v)
+    n = ninf
 }
 
 BREAKPOINT {
-	SOLVE states METHOD cnexp
-      g = gbar * n^4
-	ik = g * (v - ek)
-	igate = nc * (1e6) * e0 * 4 * zn * ngateFlip()
+    SOLVE states METHOD cnexp
+    g = gbar * n^4
+    ik = g * (v - ek)
+    igate = nc * (1e6) * e0 * 4 * zn * ngateFlip()
 
-	if (gateCurrent != 0) {
-		i = igate
-	}
+    if (gateCurrent != 0) {
+        i = igate
+    }
 }
 
 DERIVATIVE states {
-	rates(v)
-	n' = (ninf-n)/taun
+    rates(v)
+    n' = (ninf-n)/taun
 }
 
 PROCEDURE rates(v (mV)) {
-	alphan = alphanfkt(v)
-	betan = betanfkt(v)
-	ninf = alphan/(alphan+betan)
-	taun = 1/(qt*(alphan + betan))
+    alphan = alphanfkt(v)
+    betan = betanfkt(v)
+    ninf = alphan/(alphan+betan)
+    taun = 1/(qt*(alphan + betan))
 }
 
 FUNCTION alphanfkt(v (mV)) (1/ms) {
-	alphanfkt = ca * exp(-(v+cva)/cka)
+    alphanfkt = ca * exp(-(v+cva)/cka)
 }
 
 FUNCTION betanfkt(v (mV)) (1/ms) {
-	betanfkt = cb * exp(-(v+cvb)/ckb)
+    betanfkt = cb * exp(-(v+cvb)/ckb)
 }
 
 FUNCTION ngateFlip() (1/ms) {
-	ngateFlip = (ninf-n)/taun
+    ngateFlip = (ninf-n)/taun
 }
-UNITSON

--- a/mechanisms/dbbs/Kv1_1.mod
+++ b/mechanisms/dbbs/Kv1_1.mod
@@ -31,7 +31,7 @@ Contact: akemann@brain.riken.jp
 
 ENDCOMMENT
 
-
+UNITSOFF
 NEURON {
   SUFFIX Kv1_1
 	USEION k READ ek WRITE ik
@@ -134,3 +134,4 @@ FUNCTION betanfkt(v (mV)) (1/ms) {
 FUNCTION ngateFlip() (1/ms) {
 	ngateFlip = (ninf-n)/taun
 }
+UNITSON

--- a/mechanisms/dbbs/Kv3_4.mod
+++ b/mechanisms/dbbs/Kv3_4.mod
@@ -4,94 +4,94 @@
 : Suffix from kpkj to Kv3_4
 
 NEURON {
-	SUFFIX Kv3_4
-	USEION k READ ek WRITE ik
-	RANGE gkbar, ik
-	RANGE minf, hinf, mtau, htau
+    SUFFIX Kv3_4
+    USEION k READ ek WRITE ik
+    RANGE gkbar, ik
+    RANGE minf, hinf, mtau, htau
 }
 
 UNITS {
-	(mV) = (millivolt)
-	(mA) = (milliamp)
+    (mV) = (millivolt)
+    (mA) = (milliamp)
 }
 
 CONSTANT {
-	q10 = 3
+    q10 = 3
 }
 
 PARAMETER {
-	v (mV)
+    v (mV)
 
-	gkbar = .004	(mho/cm2)
+    gkbar = .004    (mho/cm2)
 
-	mivh = -24	(mV)
-	mik = 15.4	(1)
-	mty0 = .00012851
-	mtvh1 = 100.7	(mV)
-	mtk1 = 12.9	(1)
-	mtvh2 = -56.0	(mV)
-	mtk2 = -23.1	(1)
+    mivh = -24  (mV)
+    mik = 15.4  (1)
+    mty0 = .00012851
+    mtvh1 = 100.7   (mV)
+    mtk1 = 12.9 (1)
+    mtvh2 = -56.0   (mV)
+    mtk2 = -23.1    (1)
 
-	hiy0 = .31
-	hiA = .69
-	hivh = -5.802	(mV)
-	hik = 11.2	(1)
+    hiy0 = .31
+    hiA = .69
+    hivh = -5.802   (mV)
+    hik = 11.2  (1)
 
-	celsius (degC)
+    celsius (degC)
 }
 
 ASSIGNED {
-	minf
-	mtau		(ms)
-	hinf
-	htau		(ms)
+    minf
+    mtau        (ms)
+    hinf
+    htau        (ms)
     qt
 }
 
 STATE {
-	m
-	h
+    m
+    h
 }
 
 INITIAL {
-	qt = q10^((celsius-37)/10)
-	rates(v)
-	m = minf
-	h = hinf
+    qt = q10^((celsius-37)/10)
+    rates(v)
+    m = minf
+    h = hinf
 }
 
 BREAKPOINT {
-	SOLVE states METHOD cnexp
-	ik = gkbar * m^3 * h * (v - ek)
+    SOLVE states METHOD cnexp
+    ik = gkbar * m^3 * h * (v - ek)
 }
 
 DERIVATIVE states {
-	rates(v)
-	m' = (minf - m) / mtau
-	h' = (hinf - h) / htau
+    rates(v)
+    m' = (minf - m) / mtau
+    h' = (hinf - h) / htau
 }
 
-PROCEDURE rates( Vm (mV)) {
-	LOCAL v2
-	v2 = Vm + 11	: Account for Junction Potential
-	minf = 1/(1+exp(-(v2-mivh)/mik))
-	mtau = (1000) * mtau_func(v2) /qt
-	hinf = hiy0 + hiA/(1+exp((v2-hivh)/hik))
-	htau = 1000 * htau_func(v2) / qt
+PROCEDURE rates( v (mV)) {
+    LOCAL v_
+    v_ = v + 11    : Account for Junction Potential
+    minf = 1/(1+exp(-(v_-mivh)/mik))
+    mtau = (1000) * mtau_func(v_) /qt
+    hinf = hiy0 + hiA/(1+exp((v_-hivh)/hik))
+    htau = 1000 * htau_func(v_) / qt
 }
 
-FUNCTION mtau_func (Vm (mV)) (ms) {
-	if (Vm < -35) {
-		mtau_func = (3.4225e-5+.00498*exp(-Vm/-28.29))*3
-	} else {
-		mtau_func = (mty0 + 1/(exp((Vm+mtvh1)/mtk1)+exp((Vm+mtvh2)/mtk2)))
-	}
+FUNCTION mtau_func (v (mV)) (ms) {
+    if (v < -35) {
+        mtau_func = (3.4225e-5+.00498*exp(-v/-28.29))*3
+    } else {
+        mtau_func = (mty0 + 1/(exp((v+mtvh1)/mtk1)+exp((v+mtvh2)/mtk2)))
+    }
 }
 
 FUNCTION htau_func(Vm (mV)) (ms) {
-	if ( Vm > 0) {
-		htau_func = .0012+.0023*exp(-.141*Vm)
-	} else {
-		htau_func = 1.2202e-05 + .012 * exp(-((Vm-(-56.3))/49.6)^2)
-	}
+    if ( Vm > 0) {
+        htau_func = .0012+.0023*exp(-.141*Vm)
+    } else {
+        htau_func = 1.2202e-05 + .012 * exp(-((Vm-(-56.3))/49.6)^2)
+    }
 }

--- a/mechanisms/dbbs/Kv3_4.mod
+++ b/mechanisms/dbbs/Kv3_4.mod
@@ -20,7 +20,6 @@ CONSTANT {
 }
 
 PARAMETER {
-	celsius (degC)
 	v (mV)
 
 	gkbar = .004	(mho/cm2)
@@ -37,6 +36,8 @@ PARAMETER {
 	hiA = .69
 	hivh = -5.802	(mV)
 	hik = 11.2	(1)
+
+	celsius (degC)
 }
 
 ASSIGNED {
@@ -44,7 +45,7 @@ ASSIGNED {
 	mtau		(ms)
 	hinf
 	htau		(ms)
-        qt
+    qt
 }
 
 STATE {
@@ -53,11 +54,10 @@ STATE {
 }
 
 INITIAL {
+	qt = q10^((celsius-37)/10)
 	rates(v)
 	m = minf
 	h = hinf
-
-	qt = q10^((celsius-37)/10)
 }
 
 BREAKPOINT {
@@ -72,19 +72,19 @@ DERIVATIVE states {
 }
 
 PROCEDURE rates( Vm (mV)) {
-	LOCAL v_
-	v_ = Vm + 11	: Account for Junction Potential
-	minf = 1/(1+exp(-(v_-mivh)/mik))
-	mtau = (1000) * mtau_func(v_) /qt
-	hinf = hiy0 + hiA/(1+exp((v_-hivh)/hik))
-	htau = 1000 * htau_func(v_) / qt
+	LOCAL v2
+	v2 = Vm + 11	: Account for Junction Potential
+	minf = 1/(1+exp(-(v2-mivh)/mik))
+	mtau = (1000) * mtau_func(v2) /qt
+	hinf = hiy0 + hiA/(1+exp((v2-hivh)/hik))
+	htau = 1000 * htau_func(v2) / qt
 }
 
-FUNCTION mtau_func (v (mV)) (ms) {
-	if (v < -35) {
-		mtau_func = (3.4225e-5+.00498*exp(-v/-28.29))*3
+FUNCTION mtau_func (Vm (mV)) (ms) {
+	if (Vm < -35) {
+		mtau_func = (3.4225e-5+.00498*exp(-Vm/-28.29))*3
 	} else {
-		mtau_func = (mty0 + 1/(exp((v+mtvh1)/mtk1)+exp((v+mtvh2)/mtk2)))
+		mtau_func = (mty0 + 1/(exp((Vm+mtvh1)/mtk1)+exp((Vm+mtvh2)/mtk2)))
 	}
 }
 

--- a/mechanisms/dbbs/Nav1_1.mod
+++ b/mechanisms/dbbs/Nav1_1.mod
@@ -248,6 +248,6 @@ PROCEDURE rates(v(mV) )
 
 FUNCTION gateFlip() (1/ms) {
 	LOCAL flip
-  flip = f01 * C1 + (f02-b01) * C2 + (f03-b02) * C3 + (f04-b03) * C4 - b04 * C5
+    flip = f01 * C1 + (f02-b01) * C2 + (f03-b02) * C3 + (f04-b03) * C4 - b04 * C5
 	gateFlip = flip + f11 * I1 + (f12-b11) * I2	+ (f13-b12) * I3 + (f14-b13) * I4 - b14 * I5
 }

--- a/mechanisms/dbbs/Nav1_1.mod
+++ b/mechanisms/dbbs/Nav1_1.mod
@@ -23,231 +23,231 @@ Contact: akemann@brain.riken.jp
 ENDCOMMENT
 
 NEURON {
-	SUFFIX Nav1_1
-	USEION na READ ena WRITE ina
-	NONSPECIFIC_CURRENT i
-	RANGE g, gbar, ina, i, igate, nc
-	GLOBAL gateCurrent, gunit
+    SUFFIX Nav1_1
+    USEION na READ ena WRITE ina
+    NONSPECIFIC_CURRENT i
+    RANGE g, gbar, ina, i, igate, nc
+    GLOBAL gateCurrent, gunit
 }
 
 UNITS {
-	(mV) = (millivolt)
-	(mA) = (milliamp)
-	(nA) = (nanoamp)
-	(pA) = (picoamp)
-	(S)  = (siemens)
-	(mS) = (millisiemens)
-	(nS) = (nanosiemens)
-	(pS) = (picosiemens)
-	(um) = (micron)
-	(molar) = (1/liter)
-	(mM) = (millimolar)
+    (mV) = (millivolt)
+    (mA) = (milliamp)
+    (nA) = (nanoamp)
+    (pA) = (picoamp)
+    (S)  = (siemens)
+    (mS) = (millisiemens)
+    (nS) = (nanosiemens)
+    (pS) = (picosiemens)
+    (um) = (micron)
+    (molar) = (1/liter)
+    (mM) = (millimolar)
 }
 
 CONSTANT {
-	e0 = 1.60217646e-19 (coulombs)
-	q10 = 2.7
+    e0 = 1.60217646e-19 (coulombs)
+    q10 = 2.7
 }
 
 PARAMETER {
-	v	(mV)
-	celsius	(degC)
-	gateCurrent = 0			: gating currents ON = 1 OFF = 0
+    v   (mV)
+    celsius (degC)
+    gateCurrent = 0         : gating currents ON = 1 OFF = 0
 
-	gbar = 0.008 (S/cm2)
+    gbar = 0.008 (S/cm2)
 
-	zgate = 2.5435 (1)		: charge valence of activation gates
+    zgate = 2.5435 (1)      : charge valence of activation gates
 
-	gunit = 15 (pS)			: unitary conductance
+    gunit = 15 (pS)         : unitary conductance
 
-	: kinetic parameters
-	Con = 0.005			(1/ms)		: closed -> inactivated transitions
-	Coff = 0.5			(1/ms)		: inactivated -> closed transitions
-	Oon = 2.3			(1/ms)		: open -> Ineg transition
-	Ooff = 0.005		(1/ms)		: Ineg -> open transition
-	alpha = 150			(1/ms)		: activation
-	beta = 3			(1/ms)		: deactivation
-	gamma = 150			(1/ms)		: opening
-	delta = 40			(1/ms)		: closing, greater than BEAN/KUO = 0.2
-	epsilon = 1e-12		(1/ms)		: open -> Iplus for tau = 0.3 ms at +30 with x5
-	zeta = 0.03			(1/ms)		: Iplus -> open for tau = 25 ms at -30 with x6
+    : kinetic parameters
+    Con = 0.005         (1/ms)      : closed -> inactivated transitions
+    Coff = 0.5          (1/ms)      : inactivated -> closed transitions
+    Oon = 2.3           (1/ms)      : open -> Ineg transition
+    Ooff = 0.005        (1/ms)      : Ineg -> open transition
+    alpha = 150         (1/ms)      : activation
+    beta = 3            (1/ms)      : deactivation
+    gamma = 150         (1/ms)      : opening
+    delta = 40          (1/ms)      : closing, greater than BEAN/KUO = 0.2
+    epsilon = 1e-12     (1/ms)      : open -> Iplus for tau = 0.3 ms at +30 with x5
+    zeta = 0.03         (1/ms)      : Iplus -> open for tau = 25 ms at -30 with x6
 
-	: Vdep
-	x1 = 20			(mV)								: Vdep of activation (alpha)
-	x2 = -20			(mV)								: Vdep of deactivation (beta)
-	x3 = 1e12			(mV)								: Vdep of opening (gamma)
-	x4 = -1e12			(mV)								: Vdep of closing (delta)
-	x5 = 1e12			(mV)								: Vdep into Ipos (epsilon)
-	x6 = -25			(mV)								: Vdep out of Ipos (zeta)
+    : Vdep
+    x1 = 20             (mV)                                : Vdep of activation (alpha)
+    x2 = -20            (mV)                                : Vdep of deactivation (beta)
+    x3 = 1e12           (mV)                                : Vdep of opening (gamma)
+    x4 = -1e12          (mV)                                : Vdep of closing (delta)
+    x5 = 1e12           (mV)                                : Vdep into Ipos (epsilon)
+    x6 = -25            (mV)                                : Vdep out of Ipos (zeta)
 }
 
 ASSIGNED {
-	igate	(mA/cm2)
-	g	(S/cm2)
+    igate   (mA/cm2)
+    g       (S/cm2)
 
-	qt	(1)				: preexponential temperature correction
-	alfac	(1)   			: microscopic reversibility factors
-	btfac	(1)
+    qt      (1)             : preexponential temperature correction
+    alfac   (1)             : microscopic reversibility factors
+    btfac   (1)
 
-	nc	(1/cm2)			: membrane density of channels
+    nc      (1/cm2)         : membrane density of channels
 
-	: rates
-	f01  		(/ms)
-	f02  		(/ms)
-	f03 		(/ms)
-	f04			(/ms)
-	f0O 		(/ms)
-	fip 		(/ms)
-	f11 		(/ms)
-	f12 		(/ms)
-	f13 		(/ms)
-	f14 		(/ms)
-	f1n 		(/ms)
-	fi1 		(/ms)
-	fi2 		(/ms)
-	fi3 		(/ms)
-	fi4 		(/ms)
-	fi5 		(/ms)
-	fin 		(/ms)
+    : rates
+    f01         (/ms)
+    f02         (/ms)
+    f03         (/ms)
+    f04         (/ms)
+    f0O         (/ms)
+    fip         (/ms)
+    f11         (/ms)
+    f12         (/ms)
+    f13         (/ms)
+    f14         (/ms)
+    f1n         (/ms)
+    fi1         (/ms)
+    fi2         (/ms)
+    fi3         (/ms)
+    fi4         (/ms)
+    fi5         (/ms)
+    fin         (/ms)
 
-	b01 		(/ms)
-	b02 		(/ms)
-	b03 		(/ms)
-	b04		(/ms)
-	b0O 		(/ms)
-	bip 		(/ms)
-	b11  		(/ms)
-	b12 		(/ms)
-	b13 		(/ms)
-	b14 		(/ms)
-	b1n 		(/ms)
-	bi1 		(/ms)
-	bi2 		(/ms)
-	bi3 		(/ms)
-	bi4 		(/ms)
-	bi5 		(/ms)
-	bin 		(/ms)
+    b01         (/ms)
+    b02         (/ms)
+    b03         (/ms)
+    b04         (/ms)
+    b0O         (/ms)
+    bip         (/ms)
+    b11         (/ms)
+    b12         (/ms)
+    b13         (/ms)
+    b14         (/ms)
+    b1n         (/ms)
+    bi1         (/ms)
+    bi2         (/ms)
+    bi3         (/ms)
+    bi4         (/ms)
+    bi5         (/ms)
+    bin         (/ms)
 }
 
 STATE {
-	C1 FROM 0 TO 1
-	C2 FROM 0 TO 1
-	C3 FROM 0 TO 1
-	C4 FROM 0 TO 1
-	C5 FROM 0 TO 1
-	I1 FROM 0 TO 1
-	I2 FROM 0 TO 1
-	I3 FROM 0 TO 1
-	I4 FROM 0 TO 1
-	I5 FROM 0 TO 1
-	O FROM 0 TO 1
-	B FROM 0 TO 1
-	I6 FROM 0 TO 1
+    C1 FROM 0 TO 1
+    C2 FROM 0 TO 1
+    C3 FROM 0 TO 1
+    C4 FROM 0 TO 1
+    C5 FROM 0 TO 1
+    I1 FROM 0 TO 1
+    I2 FROM 0 TO 1
+    I3 FROM 0 TO 1
+    I4 FROM 0 TO 1
+    I5 FROM 0 TO 1
+    O  FROM 0 TO 1
+    B  FROM 0 TO 1
+    I6 FROM 0 TO 1
 }
 
 BREAKPOINT {
-	SOLVE activation METHOD sparse
- 	g = gbar * O
-	ina = g * (v - ena)
-	igate = nc * (1e6) * e0 * zgate * gateFlip()
+    SOLVE activation METHOD sparse
+    g = gbar * O
+    ina = g * (v - ena)
+    igate = nc * (1e6) * e0 * zgate * gateFlip()
 
-	if (gateCurrent != 0) {
-		i = igate
-	}
+    if (gateCurrent != 0) {
+        i = igate
+    }
 }
 
 INITIAL {
-	nc = (1e12) * gbar / gunit
-	qt = q10^((celsius-22)/10)
-	rates(v)
- 	SOLVE seqinitial
+    nc = (1e12) * gbar / gunit
+    qt = q10^((celsius-22)/10)
+    rates(v)
+    SOLVE seqinitial
 }
 
 KINETIC activation
 {
-	rates(v)
-	~ C1 <-> C2					(f01,b01)
-	~ C2 <-> C3					(f02,b02)
-	~ C3 <-> C4					(f03,b03)
-	~ C4 <-> C5					(f04,b04)
-	~ C5 <-> O					(f0O,b0O)
-	~ O <-> B					(fip,bip)
-	~ O <-> I6					(fin,bin)
-	~ I1 <-> I2					(f11,b11)
-	~ I2 <-> I3					(f12,b12)
-	~ I3 <-> I4					(f13,b13)
-	~ I4 <-> I5					(f14,b14)
-	~ I5 <-> I6					(f1n,b1n)
-	~ C1 <-> I1					(fi1,bi1)
-	~ C2 <-> I2					(fi2,bi2)
-	~ C3 <-> I3					(fi3,bi3)
- 	~ C4 <-> I4					(fi4,bi4)
- 	~ C5 <-> I5					(fi5,bi5)
+    rates(v)
+    ~ C1 <-> C2                 (f01,b01)
+    ~ C2 <-> C3                 (f02,b02)
+    ~ C3 <-> C4                 (f03,b03)
+    ~ C4 <-> C5                 (f04,b04)
+    ~ C5 <-> O                  (f0O,b0O)
+    ~ O <-> B                   (fip,bip)
+    ~ O <-> I6                  (fin,bin)
+    ~ I1 <-> I2                 (f11,b11)
+    ~ I2 <-> I3                 (f12,b12)
+    ~ I3 <-> I4                 (f13,b13)
+    ~ I4 <-> I5                 (f14,b14)
+    ~ I5 <-> I6                 (f1n,b1n)
+    ~ C1 <-> I1                 (fi1,bi1)
+    ~ C2 <-> I2                 (fi2,bi2)
+    ~ C3 <-> I3                 (fi3,bi3)
+    ~ C4 <-> I4                 (fi4,bi4)
+    ~ C5 <-> I5                 (fi5,bi5)
 
-CONSERVE C1 + C2 + C3 + C4 + C5 + O + B + I1 + I2 + I3 + I4 + I5 + I6 = 1
+    CONSERVE C1 + C2 + C3 + C4 + C5 + O + B + I1 + I2 + I3 + I4 + I5 + I6 = 1
 }
 
 LINEAR seqinitial { : sets initial equilibrium
- ~          I1*bi1 + C2*b01 - C1*(    fi1+f01) = 0
- ~ C1*f01 + I2*bi2 + C3*b02 - C2*(b01+fi2+f02) = 0
- ~ C2*f02 + I3*bi3 + C4*b03 - C3*(b02+fi3+f03) = 0
- ~ C3*f03 + I4*bi4 + C5*b04 - C4*(b03+fi4+f04) = 0
- ~ C4*f04 + I5*bi5 + O*b0O - C5*(b04+fi5+f0O) = 0
- ~ C5*f0O + B*bip + I6*bin - O*(b0O+fip+fin) = 0
- ~ O*fip + B*bip = 0
-
- ~          C1*fi1 + I2*b11 - I1*(    bi1+f11) = 0
- ~ I1*f11 + C2*fi2 + I3*b12 - I2*(b11+bi2+f12) = 0
- ~ I2*f12 + C3*fi3 + I4*bi3 - I3*(b12+bi3+f13) = 0
- ~ I3*f13 + C4*fi4 + I5*b14 - I4*(b13+bi4+f14) = 0
- ~ I4*f14 + C5*fi5 + I6*b1n - I5*(b14+bi5+f1n) = 0
-
- ~ C1 + C2 + C3 + C4 + C5 + O + B + I1 + I2 + I3 + I4 + I5 + I6 = 1
+     ~          I1*bi1 + C2*b01 - C1*(    fi1+f01) = 0
+     ~ C1*f01 + I2*bi2 + C3*b02 - C2*(b01+fi2+f02) = 0
+     ~ C2*f02 + I3*bi3 + C4*b03 - C3*(b02+fi3+f03) = 0
+     ~ C3*f03 + I4*bi4 + C5*b04 - C4*(b03+fi4+f04) = 0
+     ~ C4*f04 + I5*bi5 + O*b0O - C5*(b04+fi5+f0O) = 0
+     ~ C5*f0O + B*bip + I6*bin - O*(b0O+fip+fin) = 0
+     ~ O*fip + B*bip = 0
+    
+     ~          C1*fi1 + I2*b11 - I1*(    bi1+f11) = 0
+     ~ I1*f11 + C2*fi2 + I3*b12 - I2*(b11+bi2+f12) = 0
+     ~ I2*f12 + C3*fi3 + I4*bi3 - I3*(b12+bi3+f13) = 0
+     ~ I3*f13 + C4*fi4 + I5*b14 - I4*(b13+bi4+f14) = 0
+     ~ I4*f14 + C5*fi5 + I6*b1n - I5*(b14+bi5+f1n) = 0
+    
+     ~ C1 + C2 + C3 + C4 + C5 + O + B + I1 + I2 + I3 + I4 + I5 + I6 = 1
 }
 
 PROCEDURE rates(v(mV) )
 {
- alfac = (Oon/Con)^(1/4)
- btfac = (Ooff/Coff)^(1/4)
- f01 = 4 * alpha * exp(v/x1) * qt
- f02 = 3 * alpha * exp(v/x1) * qt
- f03 = 2 * alpha * exp(v/x1) * qt
- f04 = 1 * alpha * exp(v/x1) *qt
- f0O = gamma * exp(v/x3) * qt
- fip = epsilon * exp(v/x5) * qt
- f11 = 4 * alpha * alfac * exp(v/x1) * qt
- f12 = 3 * alpha * alfac * exp(v/x1) * qt
- f13 = 2 * alpha * alfac * exp(v/x1) * qt
- f14 = 1 * alpha * alfac * exp(v/x1) * qt
- f1n = gamma * exp(v/x3) * qt
- fi1 = Con * qt
- fi2 = Con * alfac * qt
- fi3 = Con * alfac^2 * qt
- fi4 = Con * alfac^3 * qt
- fi5 = Con * alfac^4 * qt
- fin = Oon * qt
-
- b01 = 1 * beta * exp(v/x2) * qt
- b02 = 2 * beta * exp(v/x2) * qt
- b03 = 3 * beta * exp(v/x2) * qt
- b04 = 4 * beta * exp(v/x2) * qt
- b0O = delta * exp(v/x4) * qt
- bip = zeta * exp(v/x6) * qt
- b11 = 1 * beta * btfac * exp(v/x2) * qt
- b12 = 2 * beta * btfac * exp(v/x2) * qt
- b13 = 3 * beta * btfac * exp(v/x2) * qt
- b14 = 4 * beta * btfac * exp(v/x2) * qt
- b1n = delta * exp(v/x4) * qt
- bi1 = Coff * qt
- bi2 = Coff * btfac * qt
- bi3 = Coff * btfac^2 * qt
- bi4 = Coff * btfac^3 * qt
- bi5 = Coff * btfac^4 * qt
- bin = Ooff * qt
+     alfac = (Oon/Con)^(1/4)
+     btfac = (Ooff/Coff)^(1/4)
+     f01 = 4 * alpha * exp(v/x1) * qt
+     f02 = 3 * alpha * exp(v/x1) * qt
+     f03 = 2 * alpha * exp(v/x1) * qt
+     f04 = 1 * alpha * exp(v/x1) *qt
+     f0O = gamma * exp(v/x3) * qt
+     fip = epsilon * exp(v/x5) * qt
+     f11 = 4 * alpha * alfac * exp(v/x1) * qt
+     f12 = 3 * alpha * alfac * exp(v/x1) * qt
+     f13 = 2 * alpha * alfac * exp(v/x1) * qt
+     f14 = 1 * alpha * alfac * exp(v/x1) * qt
+     f1n = gamma * exp(v/x3) * qt
+     fi1 = Con * qt
+     fi2 = Con * alfac * qt
+     fi3 = Con * alfac^2 * qt
+     fi4 = Con * alfac^3 * qt
+     fi5 = Con * alfac^4 * qt
+     fin = Oon * qt
+    
+     b01 = 1 * beta * exp(v/x2) * qt
+     b02 = 2 * beta * exp(v/x2) * qt
+     b03 = 3 * beta * exp(v/x2) * qt
+     b04 = 4 * beta * exp(v/x2) * qt
+     b0O = delta * exp(v/x4) * qt
+     bip = zeta * exp(v/x6) * qt
+     b11 = 1 * beta * btfac * exp(v/x2) * qt
+     b12 = 2 * beta * btfac * exp(v/x2) * qt
+     b13 = 3 * beta * btfac * exp(v/x2) * qt
+     b14 = 4 * beta * btfac * exp(v/x2) * qt
+     b1n = delta * exp(v/x4) * qt
+     bi1 = Coff * qt
+     bi2 = Coff * btfac * qt
+     bi3 = Coff * btfac^2 * qt
+     bi4 = Coff * btfac^3 * qt
+     bi5 = Coff * btfac^4 * qt
+     bin = Ooff * qt
 }
 
 FUNCTION gateFlip() (1/ms) {
-	LOCAL flip
+    LOCAL flip
     flip = f01 * C1 + (f02-b01) * C2 + (f03-b02) * C3 + (f04-b03) * C4 - b04 * C5
-	gateFlip = flip + f11 * I1 + (f12-b11) * I2	+ (f13-b12) * I3 + (f14-b13) * I4 - b14 * I5
+    gateFlip = flip + f11 * I1 + (f12-b11) * I2 + (f13-b12) * I3 + (f14-b13) * I4 - b14 * I5
 }


### PR DESCRIPTION
- Some style fixes (trailing white space, tab to spaces).
- Make sure the INITIALIZE procedure initializes all variables.
- Make some PARAMETER variables CONSTANT instead.